### PR TITLE
Add reported and discovered datetime fields to releases

### DIFF
--- a/app/Models/PackageRelease.php
+++ b/app/Models/PackageRelease.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read array<string, mixed>|null     $artifacts
  * @property-read string|null                   $signature
  * @property-read string|null                   $checksum
+ * @property-read CarbonImmutable|null          $reported
  * @property-read CarbonImmutable|null          $created_at
  * @property-read Package|null                  $package
  */
@@ -45,6 +46,7 @@ class PackageRelease extends BaseModel
             'suggests' => 'array',
             'provides' => 'array',
             'artifacts' => 'array',
+            'reported' => 'immutable_datetime',
             'created_at' => 'immutable_datetime',
         ];
     }

--- a/app/Values/Packages/FairMetadata.php
+++ b/app/Values/Packages/FairMetadata.php
@@ -101,6 +101,8 @@ readonly class FairMetadata extends DTO
             ->releases
             ->map(fn($release) => [
                 'version' => $release->version,
+                'reported' => $release->reported?->toIso8601String(),
+                'discovered' => $release->created_at?->toIso8601String(),
                 'artifacts' => $release->artifacts,
                 'provides' => $release->provides,
                 'requires' => $release->requires,

--- a/database/factories/PackageReleaseFactory.php
+++ b/database/factories/PackageReleaseFactory.php
@@ -27,6 +27,7 @@ class PackageReleaseFactory extends Factory
             'provides' => [
                 'some-feature' => $this->faker->semver(),
             ],
+            'reported' => $this->faker->dateTimeBetween('-1 year', 'now'),
             'artifacts' => [
                 'package' => [
                     [

--- a/database/migrations/2026_03_21_000000_add_reported_to_package_releases.php
+++ b/database/migrations/2026_03_21_000000_add_reported_to_package_releases.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('package_releases', function (Blueprint $table) {
+            $table->timestamp('reported')->nullable()->after('checksum');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('package_releases', function (Blueprint $table) {
+            $table->dropColumn('reported');
+        });
+    }
+};

--- a/tests/Feature/API/FAIR/PackageReleaseDatetimeFieldsTest.php
+++ b/tests/Feature/API/FAIR/PackageReleaseDatetimeFieldsTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+use App\Models\Package;
+
+beforeEach(function () {
+    Package::truncate();
+});
+
+it('includes reported and discovered datetime fields in release output', function () {
+    Package::factory()
+        ->withAuthors()
+        ->withReleases(1)
+        ->withMetas()
+        ->create([
+            'did' => 'fake:datetime-test',
+            'name' => 'Datetime Test Package',
+            'slug' => 'datetime-test',
+            'origin' => 'wp',
+            'type' => 'wp-plugin',
+            'license' => 'GPLv2',
+            'raw_metadata' => [],
+        ]);
+
+    $response = $this->getJson('/packages/fake:datetime-test')
+        ->assertStatus(200);
+
+    $releases = $response->json('releases');
+    expect($releases)->toBeArray()->not->toBeEmpty();
+
+    $release = $releases[0];
+    expect($release)
+        ->toHaveKeys(['reported', 'discovered'])
+        ->and($release['reported'])->toBeString()
+        ->and($release['discovered'])->toBeString();
+});
+
+it('returns null for reported when it is not set', function () {
+    $package = Package::factory()
+        ->withAuthors()
+        ->withMetas()
+        ->create([
+            'did' => 'fake:null-reported-test',
+            'name' => 'Null Reported Test',
+            'slug' => 'null-reported-test',
+            'origin' => 'wp',
+            'type' => 'wp-plugin',
+            'license' => 'GPLv2',
+            'raw_metadata' => [],
+        ]);
+
+    // Create a release without a reported value
+    $package->releases()->create([
+        'version' => '1.0.0',
+        'download_url' => 'https://example.com/test.zip',
+        'reported' => null,
+        'artifacts' => [
+            'package' => [['url' => 'https://example.com/test.zip', 'type' => 'zip']],
+        ],
+    ]);
+
+    $response = $this->getJson('/packages/fake:null-reported-test')
+        ->assertStatus(200);
+
+    $releases = $response->json('releases');
+    expect($releases)->toBeArray()->not->toBeEmpty();
+
+    $release = $releases[0];
+    expect($release)
+        ->toHaveKey('reported')
+        ->toHaveKey('discovered')
+        ->and($release['reported'])->toBeNull()
+        ->and($release['discovered'])->toBeString();
+});


### PR DESCRIPTION
## Summary

- Adds a nullable `reported` timestamp column to the `package_releases` table via a new migration, for storing the author-declared release date.
- Exposes `reported` and `discovered` (mapped from `created_at`) as ISO 8601 datetime strings in the FAIR metadata release output.
- Updates the `PackageRelease` model with the `reported` datetime cast and PHPDoc property.
- Adds `reported` to the `PackageReleaseFactory` definition.
- Adds tests verifying both fields appear in the API response, including a null `reported` case.

Related: https://github.com/fairpm/fair-protocol/issues/64

## Test plan

- [ ] Run `php artisan migrate` and verify the `reported` column is added to `package_releases`.
- [ ] `GET /packages/{did}` returns `reported` and `discovered` in each release object.
- [ ] `reported` is `null` when not set; otherwise it is an ISO 8601 string.
- [ ] `discovered` maps to the release's `created_at` as an ISO 8601 string.
- [ ] Run `php artisan test tests/Feature/API/FAIR/PackageReleaseDatetimeFieldsTest.php` — both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)